### PR TITLE
test(health): test health endpoints for services

### DIFF
--- a/cryostat/Chart.yaml
+++ b/cryostat/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 version: "0.1.0"
 
-appVersion: "2.1.0-dev"
+appVersion: "2.1.0"
 
 home: "https://cryostat.io"
 

--- a/cryostat/templates/tests/test-connection.yaml
+++ b/cryostat/templates/tests/test-connection.yaml
@@ -8,8 +8,15 @@ metadata:
     "helm.sh/hook": test
 spec:
   containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "cryostat.fullname" . }}:{{ .Values.core.service.port }}']
+    - name: curl
+      image: registry.access.redhat.com/ubi8/ubi:latest
+      command:
+        - '/bin/bash'
+        - '-ec'
+        - >
+          dnf install --disableplugin=subscription-manager -yq jq;
+          curl -sSf --retry 10 --retry-connrefused -o /tmp/out.json http://{{ include "cryostat.fullname" . }}:{{ .Values.core.service.httpPort }}/health;
+          cat /tmp/out.json;
+          jq -e {{ printf "(.cryostatVersion | test(\"^v%s\")) and .datasourceAvailable == true" .Chart.AppVersion | squote }} /tmp/out.json;
+          curl -sSf --retry 10 --retry-connrefused http://{{ include "cryostat.fullname" . }}-grafana:{{ .Values.grafana.service.port }}/api/health
   restartPolicy: Never


### PR DESCRIPTION
This adds a test that queries the Cryostat health endpoint with curl and verifies some values with jq. It compares the `cryostatVersion` value to the Chart's appVersion. The `2.1.0-SNAPSHOT` builds from CI don't seem to have a tag associated with them. The `cryostatVersion` is simply `26d9450`. To simulate how this will work with the released 2.1.0 image, I built an image based off of a local `v2.1.0` tag, `helm-test-01`.

The test also queries the Grafana health endpoint as well.

To test:
```
helm install cryostat cryostat/ --set core.image.repository=quay.io/ebaron/cryostat,core.image.tag=helm-test-01
helm test cryostat --logs
```

Fixes: #16 