### PR TITLE
build(schema): add JSON schema for values

### DIFF
--- a/cryostat/values.schema.json
+++ b/cryostat/values.schema.json
@@ -1,0 +1,403 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "core": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "repository": {
+                            "type": "string",
+                            "description": "Repository for the main Cryostat container image",
+                            "default": "quay.io/cryostat/cryostat"
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy for the main Cryostat container image",
+                            "default": "Always"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Tag for the main Cryostat container image",
+                            "default": "2.1.0-SNAPSHOT"
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Type of Service to create for the Cryostat application",
+                            "default": "ClusterIP"
+                        },
+                        "httpPort": {
+                            "type": "number",
+                            "description": "Port number to expose on the Service for Cryostat's HTTP server",
+                            "default": 8181
+                        },
+                        "jmxPort": {
+                            "type": "number",
+                            "description": "Port number to expose on the Service for remote JMX connections to Cryostat",
+                            "default": 9091
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether to create an Ingress object for the Cryostat service",
+                            "default": false
+                        },
+                        "className": {
+                            "type": "string",
+                            "description": "Ingress class name for the Cryostat application Ingress",
+                            "default": ""
+                        },
+                        "hosts": {
+                            "type": "array",
+                            "description": "",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "host": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "paths": {
+                                        "type": "array",
+                                        "description": "",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "path": {
+                                                    "type": "string",
+                                                    "description": ""
+                                                },
+                                                "pathType": {
+                                                    "type": "string",
+                                                    "description": ""
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "tls": {
+                            "type": "array",
+                            "description": "TLS configuration for the Cryostat application Ingress. See: [IngressSpec](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/#IngressSpec)",
+                            "default": [],
+                            "items": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "route": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether to create a Route object for the Cryostat service. Available only on OpenShift",
+                            "default": false
+                        },
+                        "tls": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Whether to secure the Cryostat application Route with TLS. See: [TLSConfig](https://docs.openshift.com/container-platform/4.10/rest_api/network_apis/route-route-openshift-io-v1.html#spec-tls)",
+                                    "default": true
+                                },
+                                "termination": {
+                                    "type": "string",
+                                    "description": "Type of TLS termination to use for the Cryostat application Route. One of: `edge`, `passthrough`, `reencrypt`",
+                                    "default": "edge"
+                                },
+                                "insecureEdgeTerminationPolicy": {
+                                    "type": "string",
+                                    "description": "Specify how to handle insecure traffic for the Cryostat application Route. One of: `Allow`, `Disable`, `Redirect`",
+                                    "default": "Redirect"
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Custom private key to use when securing the Cryostat application Route",
+                                    "default": ""
+                                },
+                                "certificate": {
+                                    "type": "string",
+                                    "description": "Custom certificate to use when securing the Cryostat application Route",
+                                    "default": ""
+                                },
+                                "caCertificate": {
+                                    "type": "string",
+                                    "description": "Custom CA certificate to use, if needed to complete the certificate chain, when securing the Cryostat application Route",
+                                    "default": ""
+                                },
+                                "destinationCACertificate": {
+                                    "type": "string",
+                                    "description": "Provides the contents of the CA certificate of the final destination when using reencrypt termination for the Cryostat application Route",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Resource requests/limits for the Cryostat container. See: [ResourceRequirements](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources)",
+                    "default": {}
+                },
+                "securityContext": {
+                    "type": "object",
+                    "description": "Security Context for the Cryostat container. See: [SecurityContext](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1)",
+                    "default": {}
+                }
+            }
+        },
+        "grafana": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "repository": {
+                            "type": "string",
+                            "description": "Repository for the Grafana container image",
+                            "default": "quay.io/cryostat/cryostat-grafana-dashboard"
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy for the Grafana container image",
+                            "default": "IfNotPresent"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Tag for the Grafana container image",
+                            "default": "2.0.0"
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Type of Service to create for Grafana",
+                            "default": "ClusterIP"
+                        },
+                        "port": {
+                            "type": "number",
+                            "description": "Port number to expose on the Service for Grafana's HTTP server",
+                            "default": 3000
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether to create an Ingress object for the Grafana service",
+                            "default": false
+                        },
+                        "hosts": {
+                            "type": "array",
+                            "description": "",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "host": {
+                                        "type": "string",
+                                        "description": ""
+                                    },
+                                    "paths": {
+                                        "type": "array",
+                                        "description": "",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "path": {
+                                                    "type": "string",
+                                                    "description": ""
+                                                },
+                                                "pathType": {
+                                                    "type": "string",
+                                                    "description": ""
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "className": {
+                            "type": "string",
+                            "description": "Ingress class name for the Grafana Ingress",
+                            "default": ""
+                        },
+                        "tls": {
+                            "type": "array",
+                            "description": "TLS configuration for the Grafana Ingress. See: [IngressSpec](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/#IngressSpec)",
+                            "default": [],
+                            "items": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "route": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether to create a Route object for the Grafana service. Available only on OpenShift",
+                            "default": false
+                        },
+                        "tls": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Whether to secure the Grafana Route with TLS. See: [TLSConfig](https://docs.openshift.com/container-platform/4.10/rest_api/network_apis/route-route-openshift-io-v1.html#spec-tls)",
+                                    "default": true
+                                },
+                                "termination": {
+                                    "type": "string",
+                                    "description": "Type of TLS termination to use for the Grafana Route. One of: `edge`, `passthrough`, `reencrypt`",
+                                    "default": "edge"
+                                },
+                                "insecureEdgeTerminationPolicy": {
+                                    "type": "string",
+                                    "description": "Specify how to handle insecure traffic for the Grafana Route. One of: `Allow`, `Disable`, `Redirect`",
+                                    "default": "Redirect"
+                                },
+                                "key": {
+                                    "type": "string",
+                                    "description": "Custom private key to use when securing the Grafana Route",
+                                    "default": ""
+                                },
+                                "certificate": {
+                                    "type": "string",
+                                    "description": "Custom certificate to use when securing the Grafana Route",
+                                    "default": ""
+                                },
+                                "caCertificate": {
+                                    "type": "string",
+                                    "description": "Custom CA certificate to use, if needed to complete the certificate chain, when securing the Grafana Route",
+                                    "default": ""
+                                },
+                                "destinationCACertificate": {
+                                    "type": "string",
+                                    "description": "Provides the contents of the CA certificate of the final destination when using reencrypt termination for the Grafana Route",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Resource requests/limits for the Grafana container. See: [ResourceRequirements](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources)",
+                    "default": {}
+                },
+                "securityContext": {
+                    "type": "object",
+                    "description": "Security Context for the Grafana container. See: [SecurityContext](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1)",
+                    "default": {}
+                }
+            }
+        },
+        "datasource": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "repository": {
+                            "type": "string",
+                            "description": "Repository for the JFR Data Source container image",
+                            "default": "quay.io/cryostat/jfr-datasource"
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Image pull policy for the JFR Data Source container image",
+                            "default": "IfNotPresent"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Tag for the JFR Data Source container image",
+                            "default": "2.0.0"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "description": "Resource requests/limits for the JFR Data Source container. See: [ResourceRequirements](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources)",
+                    "default": {}
+                },
+                "securityContext": {
+                    "type": "object",
+                    "description": "Security Context for the JFR Data Source container. See: [SecurityContext](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1)",
+                    "default": {}
+                }
+            }
+        },
+        "imagePullSecrets": {
+            "type": "array",
+            "description": "Image pull secrets to be used for the Cryostat deployment",
+            "default": [],
+            "items": {
+                "type": "object"
+            }
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "Overrides the name of this Chart",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "Overrides the fully qualified application name of `[release name]-[chart name]`",
+            "default": ""
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether RBAC resources should be created",
+                    "default": true
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Specifies whether a service account should be created",
+                    "default": true
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the service account to use. If not set and create is true, a name is generated using the fullname template",
+                    "default": ""
+                }
+            }
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Tolerations for the Cryostat Pod. See: [Tolerations](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling)",
+            "default": [],
+            "items": {
+                "type": "object"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Generated using readme-generator-for-helm, which also generates our README. I had to manually set the type for the items property of empty arrays. This was set to the empty string, but Helm doesn't seem to like that. Changing them to `object` fixed the issue.

Fixes: #18 