### PR TITLE
Allow SSL Proxied EnvVars to be enabled outside of Ingress Configuration

### DIFF
--- a/cryostat/templates/deployment.yaml
+++ b/cryostat/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           - name: CRYOSTAT_PROBE_TEMPLATE_PATH
             value: /opt/cryostat.d/probes.d
           - name: CRYOSTAT_EXT_WEB_PORT
-            value: "{{ if (or (and .Values.core.route.enabled .Values.core.route.tls.enabled) (and .Values.core.ingress.enabled .Values.core.ingress.tls)) }}443{{ else }}80{{ end }}"
+            value: "{{ if (or (and .Values.core.route.enabled .Values.core.route.tls.enabled) (and .Values.core.ingress.enabled .Values.core.ingress.tls) (.Values.core.sslProxied)) }}443{{ else }}80{{ end }}"
           - name: CRYOSTAT_WEB_HOST
             value: "{{ if .Values.core.ingress.enabled }}{{ with index .Values.core.ingress.hosts 0 }}{{ .host }}{{ end }}{{ end }}"
           - name: CRYOSTAT_PLATFORM
@@ -54,7 +54,7 @@ spec:
           - name: GRAFANA_DATASOURCE_URL
             value: http://127.0.0.1:8080
           - name: GRAFANA_DASHBOARD_URL
-            value: "{{ if .Values.grafana.ingress.enabled }}http{{ if .Values.grafana.ingress.tls }}s{{ end }}://{{ with index .Values.grafana.ingress.hosts 0 }}{{ .host }}{{ end }}{{ end }}"
+            value: "{{ if .Values.grafana.ingress.enabled }}http{{ if (or (.Values.grafana.ingress.tls) (.Values.core.sslProxied)) }}s{{ end }}://{{ with index .Values.grafana.ingress.hosts 0 }}{{ .host }}{{ end }}{{ end }}"
           - name: CRYOSTAT_DISABLE_SSL
             value: "true"
           - name: CRYOSTAT_DISABLE_JMX_AUTH
@@ -63,7 +63,7 @@ spec:
             value: "true"
           - name: CRYOSTAT_ENABLE_JDP_BROADCAST
             value: "false"
-          {{- if (or (and .Values.core.route.enabled .Values.core.route.tls.enabled) (and .Values.core.ingress.enabled .Values.core.ingress.tls)) }}
+          {{- if (or (and .Values.core.route.enabled .Values.core.route.tls.enabled) (and .Values.core.ingress.enabled .Values.core.ingress.tls) (.Values.core.sslProxied)) }}
           - name: CRYOSTAT_SSL_PROXIED
             value: "true"
           {{- end }}

--- a/cryostat/values.yaml
+++ b/cryostat/values.yaml
@@ -15,6 +15,8 @@ core:
     httpPort: 8181
     ## @param core.service.jmxPort Port number to expose on the Service for remote JMX connections to Cryostat
     jmxPort: 9091
+  ## @param core.sslProxied Enables SSL Proxied Environment Variables, useful when you are offloading SSL/TLS at External Loadbalancer instead of Ingress
+  sslProxied: false
   ingress:
     ## @param core.ingress.enabled Whether to create an Ingress object for the Cryostat service
     enabled: false


### PR DESCRIPTION
Hi cryostat helm chart maintainers!

This PR adds the ability to set up a parameter `core.sslProxied` in order to enable all the "SSL Proxied" environment variables outside of ingress/route tls configuration.

The main reason behind this is that when you are offloading at the loadbalancer and not at the ingress you have no way currently to enable this settings in the current version of the chart.

I've tested this in my current deployment of cryostat and seems to work fine, I stopped receiving errors related to connection errors.