### PR TITLE
feat(discovery): generate password for credentials database

### DIFF
--- a/cryostat/README.md
+++ b/cryostat/README.md
@@ -29,6 +29,7 @@ A Helm chart for deploying [Cryostat](https://cryostat.io/) on Kubernetes and Op
 | `core.route.tls.destinationCACertificate`      | Provides the contents of the CA certificate of the final destination when using reencrypt termination for the Cryostat application Route                                                        | `""`                        |
 | `core.resources`                               | Resource requests/limits for the Cryostat container. See: [ResourceRequirements](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources)                      | `{}`                        |
 | `core.securityContext`                         | Security Context for the Cryostat container. See: [SecurityContext](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1)                          | `{}`                        |
+| `core.databaseSecretName`                      | Name of the secret to extract password for credentials database.                                                                                                                                | `""`                        |
 
 
 ### Grafana Container

--- a/cryostat/templates/_helpers.tpl
+++ b/cryostat/templates/_helpers.tpl
@@ -60,3 +60,21 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Get or generate a default password for credentials database
+*/}}
+{{- define "cryostat.databasePassword" -}}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace "cryostat-jmx-credentials-db") -}}
+{{- if $secret -}}
+{{/*
+   Use current password. Do not regenerate
+*/}}
+{{-  $secret.data.CRYOSTAT_JMX_CREDENTIALS_DB_PASSWORD -}}
+{{- else -}}
+{{/*
+    Generate new password
+*/}}
+{{- (randAlphaNum 32) | b64enc | quote -}}
+{{- end -}}
+{{- end -}}

--- a/cryostat/templates/deployment.yaml
+++ b/cryostat/templates/deployment.yaml
@@ -67,6 +67,11 @@ spec:
           - name: CRYOSTAT_SSL_PROXIED
             value: "true"
           {{- end }}
+          - name: CRYOSTAT_JMX_CREDENTIALS_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{- default "cryostat-jmx-credentials-db" .Values.core.databaseSecretName -}}
+                key: CRYOSTAT_JMX_CREDENTIALS_DB_PASSWORD
           ports:
             - containerPort: 8181
               protocol: TCP

--- a/cryostat/templates/secret.yaml
+++ b/cryostat/templates/secret.yaml
@@ -1,0 +1,9 @@
+{{- if empty .Values.core.databaseSecretName -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cryostat-jmx-credentials-db
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  CRYOSTAT_JMX_CREDENTIALS_DB_PASSWORD: {{ include "cryostat.databasePassword" . }}

--- a/cryostat/values.schema.json
+++ b/cryostat/values.schema.json
@@ -157,6 +157,11 @@
                     "type": "object",
                     "description": "Security Context for the Cryostat container. See: [SecurityContext](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1)",
                     "default": {}
+                },
+                "databaseSecretName": {
+                    "type": "string",
+                    "description": "Name of the secret to extract password for credentials database.",
+                    "default": ""
                 }
             }
         },

--- a/cryostat/values.yaml
+++ b/cryostat/values.yaml
@@ -52,6 +52,8 @@ core:
   resources: {}
   ## @param core.securityContext Security Context for the Cryostat container. See: [SecurityContext](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1)
   securityContext: {}
+  ## @param core.databaseSecretName Name of the secret to extract password for credentials database.
+  databaseSecretName: ""
 
 ## @section Grafana Container
 ## @extra grafana Configuration for the customized Grafana instance for Cryostat


### PR DESCRIPTION
Fixes #37 

User can have option to specify the secret name containing the password (i.e must have valid key) or choose to use generated password.