### PR TITLE
chore(chart): specify kubeVersion constraints

### DIFF
--- a/cryostat/Chart.yaml
+++ b/cryostat/Chart.yaml
@@ -6,6 +6,8 @@ type: application
 
 version: "0.2.0"
 
+kubeVersion: ">= 1.19.0"
+
 appVersion: "latest"
 
 home: "https://cryostat.io"


### PR DESCRIPTION
Fixes #45 

Specified k8s version constraint in `Chart`.yaml. 

Reference: https://helm.sh/docs/topics/charts/#the-kubeversion-field