### PR TITLE
fix(chart): consider pre-release versioning

### DIFF
--- a/cryostat/Chart.yaml
+++ b/cryostat/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 version: "0.4.0-dev"
 
-kubeVersion: ">= 1.19.0"
+kubeVersion: ">= 1.19.0-0"
 
 appVersion: "latest"
 


### PR DESCRIPTION
Helm's `semverCompare` function does not seem to consider the [pre-release component](https://semver.org/#spec-item-9) in Semantic Versioning, unless explicitly specified in the comparison string. See: https://github.com/helm/helm/issues/10375

Fixes: #53 