### PR TITLE
fix(secret): use release name in database secret

### DIFF
--- a/cryostat/templates/_helpers.tpl
+++ b/cryostat/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use
 Get or generate a default password for credentials database
 */}}
 {{- define "cryostat.databasePassword" -}}
-{{- $secret := (lookup "v1" "Secret" .Release.Namespace "cryostat-jmx-credentials-db") -}}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-jmx-credentials-db" .Release.Name)) -}}
 {{- if $secret -}}
 {{/*
    Use current password. Do not regenerate

--- a/cryostat/templates/deployment.yaml
+++ b/cryostat/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
           - name: CRYOSTAT_JMX_CREDENTIALS_DB_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ default "cryostat-jmx-credentials-db" .Values.core.databaseSecretName }}
+                name: {{ default (printf "%s-jmx-credentials-db" .Release.Name) .Values.core.databaseSecretName }}
                 key: CRYOSTAT_JMX_CREDENTIALS_DB_PASSWORD
                 optional: false
           ports:

--- a/cryostat/templates/secret.yaml
+++ b/cryostat/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: cryostat-jmx-credentials-db
+  name: {{ .Release.Name }}-jmx-credentials-db
 type: Opaque
 data:
   CRYOSTAT_JMX_CREDENTIALS_DB_PASSWORD: {{ include "cryostat.databasePassword" . }}


### PR DESCRIPTION
Fixes #62 

Prefix secret name with release's name to avoid conflicts with other releases in the same namespace.