### PR TITLE
ci(submodule): automatic update submodule on gh-pages push

### DIFF
--- a/.github/workflows/submodule.yml
+++ b/.github/workflows/submodule.yml
@@ -1,0 +1,32 @@
+name: submodule
+
+on:
+  push:
+    branches:
+      - gh-pages
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  update-submodule:
+    if: ${{ github.repository_owner == 'cryostatio' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: cryostatio/cryostatio.github.io
+        token: "${{ secrets.SUBMODULE_TOKEN }}"
+    - name: Update submodule to latest commit
+      run: |
+        git submodule update --init
+        git submodule update --remote
+    - name: Commit and push submodule
+      run: |
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+        git add --all
+        git_hash="$(git rev-parse --short :helm-charts)"
+        git commit -m "build(helm-charts): update submodule to $git_hash" || echo "No changes to commit"
+        git push


### PR DESCRIPTION
Related to #71 
Fixes #78 

Add workflow to automatically update submodule on pushs (i.e. new releases).

**Notes: Require `${{ secrets.SUBMODULE_TOKEN }}` to push new commits**.