### PR TITLE
chore(storage): remove storage volume parameter overrides

### DIFF
--- a/charts/cryostat/templates/deployment.yaml
+++ b/charts/cryostat/templates/deployment.yaml
@@ -164,13 +164,6 @@ spec:
                 optional: false
           - name: DATA_DIR
             value: /data
-          # TODO tune these or make them configurable. Ideally the single seaweed volume server should consume the entire PVC
-          - name: VOLUME_PREALLOCATE
-            value: "false"
-          - name: VOLUME_SIZE_LIMIT_MB
-            value: "500"
-          - name: VOLUME_MAX
-            value: "16"
           - name: IP_BIND
             value: 0.0.0.0
           ports:


### PR DESCRIPTION
Depends on #127
Based on #127
See https://github.com/cryostatio/cryostat-storage/pull/14

Remove SeaweedFS volume tuning parameter overrides.

To test:

```bash
$ helm install cryostat --set authentication.openshift.enabled=true --set core.route.enabled=true --set openshiftOauthProxy.image.repository=quay.io/andrewazores/openshift-oauth-proxy --set openshiftOauthProxy.image.tag=test-14 --set authentication.basicAuth.enabled=true --set authentication.basicAuth.secretName=basicauth --set authentication.basicAuth.filename=htpasswd.conf --set storage.image.repository=quay.io/andrewazores/cryostat-storage --set storage.image.tag=volume-tuning-1 --set pvc.enabled=true --set pvc.storage=2Gi ./charts/cryostat/
```

This installs the Helm chart with an openshift-oauth-proxy (not actually required for this change to work, but it's how I tested it) and with a storage container built from https://github.com/cryostatio/cryostat-storage/pull/14 . It requests a 2Gi PVC, but depending on the cluster the actual provisioned storage may be larger.

I then opened the web UI, defined a `localhost:0` custom target for Cryostat to be able to monitor itself, and manually started a continuous flight recording with the `ALL` meta-template.

Then I ran the following:

```bash
$ while true; do curl -k 'https://user:pass@cryostat-storage-tuning.apps-crc.testing/api/v3/targets/1/recordings/1' --compressed -X PATCH -H 'Accept: */*' -H 'Accept-Encoding: gzip, deflate, br' -H 'Content-Type: text/plain;charset=UTF-8' --data-raw SAVE; sleep 10; done
```

So every 10 seconds, the script will fire a `curl` to ask Cryostat to archive that recording. Then I opened the Archives > All Archives view in the web UI, and from my OpenShift cluster's console I opened the Storage > PersistentVolumeClaims view and ensured that as new archived recordings were created that the PVC utilization increased by roughly the same amount (a little more to account for associated metadata). I also used `oc exec -it cryostat-pod -c cryostat-storage /bin/bash` to inspect the contents of the PVC directly with `df -h` and `ls -l /data`.