### PR TITLE
fix(authproxy): set openshift oauth proxy prefix to match oauth2_proxy prefix

### DIFF
--- a/charts/cryostat/templates/openshiftOauthProxy.tpl
+++ b/charts/cryostat/templates/openshiftOauthProxy.tpl
@@ -15,6 +15,7 @@
     - --https-address=:8443
     - --tls-cert=/etc/tls/private/tls.crt
     - --tls-key=/etc/tls/private/tls.key
+    - --proxy-prefix=/oauth2
     {{- if .Values.authentication.basicAuth.enabled }}
     - --htpasswd-file=/etc/openshift_oauth_proxy/basicauth/{{ .Values.authentication.basicAuth.filename }}
     {{- end }}


### PR DESCRIPTION
Fixes https://github.com/cryostatio/cryostat3/issues/365
Depends on https://github.com/cryostatio/cryostat3/pull/366
