### PR TITLE
fix(notes): remove duplicate env var in release notes for clusterIP mode

### DIFF
--- a/charts/cryostat/templates/NOTES.txt
+++ b/charts/cryostat/templates/NOTES.txt
@@ -29,7 +29,6 @@
   export CONTAINER_PORT=$(kubectl get pod -n {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   export CRYOSTAT_WEB_HOST=localhost
 {{- $envVars = list "QUARKUS_HTTP_HOST=$CRYOSTAT_WEB_HOST" }}
-{{- $envVars = append $envVars ( tpl "QUARKUS_HTTP_HOST=$CRYOSTAT_WEB_HOST" . ) }}
 {{- $envVars = append $envVars ( tpl "STORAGE_EXT_URL=http://$CRYOSTAT_WEB_HOST:8080/storage/" . ) }}
 {{- $envVars = append $envVars ( tpl "GRAFANA_DASHBOARD_EXT_URL=http://$CRYOSTAT_WEB_HOST:8080/grafana/" . ) }}
 {{- $portForwards = prepend $portForwards "8080:$CONTAINER_PORT" }}


### PR DESCRIPTION
Related to #110 

Remove duplicate env var in release note for deployment patching command.

### Before

```bash
kubectl -n myns set env deploy --containers=cryostat cryostat QUARKUS_HTTP_HOST=$CRYOSTAT_WEB_HOST QUARKUS_HTTP_HOST=$CRYOSTAT_WEB_HOST STORAGE_EXT_URL=http://$CRYOSTAT_WEB_HOST:8080/storage/ GRAFANA_DASHBOARD_EXT_URL=http://$CRYOSTAT_WEB_HOST:8080/grafana/
```

### After

```bash
kubectl -n myns set env deploy --containers=cryostat cryostat QUARKUS_HTTP_HOST=$CRYOSTAT_WEB_HOST STORAGE_EXT_URL=http://$CRYOSTAT_WEB_HOST:8080/storage/ GRAFANA_DASHBOARD_EXT_URL=http://$CRYOSTAT_WEB_HOST:8080/grafana/

```