### PR TITLE
fix(upgrade): fix errors during chart version upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,21 +27,22 @@ on:
 
 env:
   TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
+  TEST_NAMESPACE: helm-test
 
 jobs:
   lint-chart:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v4
         with:
-          version: v3.11.2
-      - uses: actions/setup-python@v4
+          version: v3.14.4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.x'
           check-latest: true
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1
@@ -53,23 +54,30 @@ jobs:
     - name: Fail if safe-to-test label NOT applied
       if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
       run: exit 1
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Helm
-      uses: azure/setup-helm@v3
+      uses: azure/setup-helm@v4
       with:
-        version: v3.11.2
-    - uses: actions/setup-python@v4
+        version: v3.14.4
+    - uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.x'
         check-latest: true
     - uses: helm/chart-testing-action@v2.6.1
     - name: Set up Kind cluster
-      run: kind create cluster -n ci-${{ github.run_id }}
+      uses: helm/kind-action@v1
+      with:
+        cluster_name: ci-${{ github.run_id }}
     - name: Install and test chart
       run: |
-        kubectl create ns helm-test
-        ct install --target-branch ${TARGET_BRANCH} --upgrade --namespace=helm-test --config ct.yaml
-    - name: Clean up Kind cluster
-      run: kind delete cluster -n ci-${{ github.run_id }}
+        # FIXME: Remove when chart-testing fixes the issue https://github.com/helm/chart-testing/issues/525
+        
+        HELM_LOCATION="$(which helm)"
+        sudo mv $HELM_LOCATION "$(dirname $HELM_LOCATION)/.helm"
+        cat <(echo '#!/usr/bin/env bash') <(echo 'exec .helm "${@//--reuse-values/--reset-then-reuse-values}"') | sudo tee $HELM_LOCATION
+        sudo chmod +x $HELM_LOCATION
+
+        kubectl create ns $TEST_NAMESPACE
+        ct install --target-branch ${TARGET_BRANCH} --upgrade --namespace=$TEST_NAMESPACE --config ct.yaml --debug

--- a/charts/cryostat/ci/minimal-deploy-values.yaml
+++ b/charts/cryostat/ci/minimal-deploy-values.yaml
@@ -1,1 +1,0 @@
-minimal: true

--- a/charts/cryostat/ci/non-minimal-deploy-values.yaml
+++ b/charts/cryostat/ci/non-minimal-deploy-values.yaml
@@ -1,1 +1,0 @@
-minimal: false

--- a/charts/cryostat/templates/_helpers.tpl
+++ b/charts/cryostat/templates/_helpers.tpl
@@ -88,7 +88,7 @@ Get or generate a default encryption key for credentials database
 {{/*
    Use current key. Do not regenerate
 */}}
-{{- $secret.data.CRYOSTAT_JMX_CREDENTIALS_DB_PASSWORD -}}
+{{- $secret.data.ENCRYPTION_KEY -}}
 {{- else -}}
 {{/*
     Generate new key

--- a/charts/cryostat/templates/deployment.yaml
+++ b/charts/cryostat/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        {{- if .Values.authentication.openshift.enabled }}
+        {{- if (.Values.authentication.openshift).enabled }}
         {{- include "openshiftOauthProxy" . | nindent 8 }}
         {{- else }}
         {{- include "oauth2Proxy" . | nindent 8 }}
@@ -111,9 +111,9 @@ spec:
             {{- toYaml .Values.core.resources | nindent 12 }}
         - name: {{ printf "%s-%s" .Chart.Name "db" }}
           securityContext:
-            {{- toYaml .Values.db.securityContext | nindent 12 }}
-          image: "{{ .Values.db.image.repository }}:{{ .Values.db.image.tag }}"
-          imagePullPolicy: {{ .Values.db.image.pullPolicy }}
+            {{- toYaml (.Values.db).securityContext | nindent 12 }}
+          image: "{{ (.Values.db).image.repository }}:{{ (.Values.db).image.tag }}"
+          imagePullPolicy: {{ (.Values.db).image.pullPolicy }}
           env:
           - name: POSTGRESQL_USER
             value: cryostat3
@@ -148,9 +148,9 @@ spec:
               - cryostat3
         - name: {{ printf "%s-%s" .Chart.Name "storage" }}
           securityContext:
-            {{- toYaml .Values.storage.securityContext | nindent 12 }}
-          image: "{{ .Values.storage.image.repository }}:{{ .Values.storage.image.tag }}"
-          imagePullPolicy: {{ .Values.storage.image.pullPolicy }}
+            {{- toYaml (.Values.storage).securityContext | nindent 12 }}
+          image: "{{ (.Values.storage).image.repository }}:{{ (.Values.storage).image.tag }}"
+          imagePullPolicy: {{ (.Values.storage).image.pullPolicy }}
           env:
           - name: CRYOSTAT_BUCKETS
             value: archivedrecordings,archivedreports,eventtemplates
@@ -193,9 +193,9 @@ spec:
             periodSeconds: 10
             failureThreshold: 9
           resources:
-            {{- toYaml .Values.storage.resources | nindent 12 }}
+            {{- toYaml (.Values.storage).resources | nindent 12 }}
           securityContext:
-            {{- toYaml .Values.storage.securityContext | nindent 12 }}
+            {{- toYaml (.Values.storage).securityContext | nindent 12 }}
         - name: {{ printf "%s-%s" .Chart.Name "grafana" }}
           securityContext:
             {{- toYaml .Values.grafana.securityContext | nindent 12 }}
@@ -273,7 +273,7 @@ spec:
           defaultMode: 0440
           secretName: {{ .Values.authentication.basicAuth.secretName }}
       {{- end }}
-      {{- if .Values.authentication.openshift.enabled }}
+      {{- if (.Values.authentication.openshift).enabled }}
       - name: {{ .Release.Name }}-proxy-tls
         secret:
           secretName: {{ .Release.Name }}-proxy-tls

--- a/charts/cryostat/templates/oauth2Proxy.tpl
+++ b/charts/cryostat/templates/oauth2Proxy.tpl
@@ -1,11 +1,11 @@
 {{- define "oauth2Proxy" }}
 - name: {{ printf "%s-%s" .Chart.Name "authproxy" }}
   securityContext:
-    {{- toYaml .Values.oauth2Proxy.securityContext | nindent 12 }}
-  image: "{{ .Values.oauth2Proxy.image.repository }}:{{ .Values.oauth2Proxy.image.tag }}"
+    {{- toYaml (.Values.oauth2Proxy).securityContext | nindent 12 }}
+  image: "{{ (.Values.oauth2Proxy).image.repository }}:{{ (.Values.oauth2Proxy).image.tag }}"
   args:
     - "--alpha-config=/etc/oauth2_proxy/alpha_config/alpha_config.yaml"
-  imagePullPolicy: {{ .Values.oauth2Proxy.image.pullPolicy }}
+  imagePullPolicy: {{ (.Values.oauth2Proxy).image.pullPolicy }}
   env:
     - name: OAUTH2_PROXY_REDIRECT_URL
       value: "http://localhost:4180/oauth2/callback"

--- a/charts/cryostat/templates/service.yaml
+++ b/charts/cryostat/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "cryostat.labels" $ | nindent 4 }}
-  {{- if .Values.authentication.openshift.enabled }}
+  {{- if (.Values.authentication.openshift).enabled }}
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: {{ .Release.Name }}-proxy-tls
   {{- end }}

--- a/charts/cryostat/templates/serviceaccount.yaml
+++ b/charts/cryostat/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.authentication.openshift.enabled -}}
+{{- if (.Values.authentication.openshift).enabled -}}
 {{- $fullName := include "cryostat.fullname" . -}}
 {{- $redirectAnnotations := dict "serviceaccounts.openshift.io/oauth-redirectreference.primary" (printf "{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"%s\"}}" $fullName) -}}
 {{- $_ := merge .Values.serviceAccount.annotations $redirectAnnotations -}}


### PR DESCRIPTION
Related to #124 

## What's changed

- Wrapped new configurations in `()` for nil-checks. See [here](https://stackoverflow.com/questions/59795596/how-to-make-nested-variables-optional-in-helm/68807258#68807258).
  - However, this is just for safe guarding, not solving the upgrade failures. See below.
- Create a wrapper that forces helm to use `--reset-then-reuse-values`. This is available only with helm 3.14+.
  - The user cannot use `helm upgrade --reuse-values` as it would cause values such as `(.Values.storage).image.repository` to be empty. This is an invalid image repository.
  - Helm 3.14+ has a new feature with `--reset-then-reuse-values`: https://github.com/helm/helm/pull/9653 that fits our upgrade path more.
  - However, `chart-testing` has not been updated for accommodate that so this is a temporary fix.

- Removed unused test value files (minimal mode is removed).
- Upgraded related github actions.

## What's motivation

The test is failing because chart-testing `ct` is also testing upgrade path with `--reuse-values`. This causes `nil` pointer error as old values do not have newly defined fields in 3.0.

## Sample run

[Sample PR](https://github.com/tthvo/cryostat-helm/pull/7): https://github.com/tthvo/cryostat-helm/actions/runs/9061712431/job/24894069674?pr=7
