### PR TITLE
chore(deployment): remove unused containerPort spec

### DIFF
--- a/charts/cryostat/templates/deployment.yaml
+++ b/charts/cryostat/templates/deployment.yaml
@@ -108,10 +108,6 @@ spec:
           ports:
             - containerPort: 8181
               protocol: TCP
-            - containerPort: 9090
-              protocol: TCP
-            - containerPort: 9091
-              protocol: TCP
           livenessProbe:
             httpGet:
               path: "/health/liveness"


### PR DESCRIPTION
Related to #140 


## Descriptions

Removed unused `containerPort` in Cryostat container's spec. The list is actually immutable but since deployment rollout strategy is `Recreate`, updating across upgrades is possible.

https://github.com/cryostatio/cryostat-helm/blob/4d14d68a9dfefd215ff5d0a2d014a6aa6014cb4b/charts/cryostat/templates/deployment.yaml#L12

```
$ oc explain pod.spec.containers.ports
KIND:       Pod
VERSION:    v1

FIELD: ports <[]ContainerPort>

DESCRIPTION:
    List of ports to expose from the container. Not specifying a port here DOES
    NOT prevent that port from being exposed. Any port which is listening on the
    default "0.0.0.0" address inside a container will be accessible from the
    network. Modifying this array with strategic merge patch may corrupt the
    data. For more information See
    https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
    ContainerPort represents a network port in a single container.

```