### PR TITLE
chore(service): https port should not be exposed on k8s environment

### DIFF
--- a/charts/cryostat/templates/service.yaml
+++ b/charts/cryostat/templates/service.yaml
@@ -17,9 +17,11 @@ spec:
       targetPort: 4180
       protocol: TCP
       name: cryostat-http
+    {{- if (.Values.authentication.openshift).enabled }}
     - port: 443
       targetPort: 8443
       protocol: TCP
       name: cryostat-https
+    {{- end }}
   selector:
     {{- include "cryostat.selectorLabels" $ | nindent 4 }}


### PR DESCRIPTION
Related to #159 
Related to #127

## Descriptions

Un-exposed invalid port definition in Service (i.e. https port) that is not yet implemented on non-OpenShift environment.


```
NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE    SELECTOR
cryostat     ClusterIP   10.110.17.206   <none>        8181/TCP   55s    app.kubernetes.io/instance=cryostat,app.kubernetes.io/name=cryostat
```

## Motivations

https://github.com/cryostatio/cryostat-helm/pull/159#discussion_r1671083612