### PR TITLE
chore(kubeVersion): bump min support k8s version to 1.25.0

### DIFF
--- a/charts/cryostat/Chart.yaml
+++ b/charts/cryostat/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 version: "0.5.0-dev"
 
-kubeVersion: ">= 1.21.0-0"
+kubeVersion: ">= 1.25.0-0"
 
 appVersion: "4.0.0-dev"
 


### PR DESCRIPTION
Fixes #169 

## Descriptions

Bumped min support k8s version to 1.25.0

## Motivations

See #169. The chart `version` should probably be `1.x` (See https://github.com/cryostatio/cryostat-helm/pull/159#discussion_r1674801222). But for backporting, that can be done in another PR ^^
