### PR TITLE
chore(version): bump chart version to 2.0.0-dev

### DIFF
--- a/charts/cryostat/Chart.yaml
+++ b/charts/cryostat/Chart.yaml
@@ -4,7 +4,7 @@ description: Securely manage JFR recordings for your containerized Java workload
 
 type: application
 
-version: "0.5.0-dev"
+version: "2.0.0-dev"
 
 kubeVersion: ">= 1.25.0-0"
 


### PR DESCRIPTION
Related to #159 

Bumped chart version to `2.0.0-dev`.

## Motivations

See https://github.com/cryostatio/cryostat-helm/pull/159#discussion_r1678378122