### PR TITLE
ci(oci): use standard token for pushing package

### DIFF
--- a/.github/workflows/push-oci.yml
+++ b/.github/workflows/push-oci.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_PKGS_WRITE }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push charts to GHCR
         run: |
           for pkg in .cr-release-packages/*.tgz; do


### PR DESCRIPTION
See #173
