### PR TITLE
chore(notes): simplify post-install steps for ClusterIP service case

### DIFF
--- a/charts/cryostat/templates/NOTES.txt
+++ b/charts/cryostat/templates/NOTES.txt
@@ -52,7 +52,7 @@
 {{- else if .Values.core.ingress.enabled }}
 {{- range $host := .Values.core.ingress.hosts -}}
   {{- range .paths }}
-  echo {{ ternary "http" "https" (empty $.Values.core.ingress.tls) }}://{{ $host.host }}{{ .path }}
+  {{ ternary "http" "https" (empty $.Values.core.ingress.tls) }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.core.service.type }}
@@ -60,6 +60,6 @@
 {{- else if contains "LoadBalancer" .Values.core.service.type }}
   echo http://$SERVICE_IP:{{ .Values.core.service.httpPort }}
 {{- else if contains "ClusterIP" .Values.core.service.type }}
-  echo http://localhost:8080
+  http://localhost:8080
 {{- end }}
   ```

--- a/charts/cryostat/templates/NOTES.txt
+++ b/charts/cryostat/templates/NOTES.txt
@@ -52,7 +52,7 @@
 {{- else if .Values.core.ingress.enabled }}
 {{- range $host := .Values.core.ingress.hosts -}}
   {{- range .paths }}
-  {{ ternary "http" "https" (empty $.Values.core.ingress.tls) }}://{{ $host.host }}{{ .path }}
+  echo {{ ternary "http" "https" (empty $.Values.core.ingress.tls) }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.core.service.type }}

--- a/charts/cryostat/templates/NOTES.txt
+++ b/charts/cryostat/templates/NOTES.txt
@@ -33,6 +33,7 @@
 {{- end }}
 
 {{- if $portForwards }}
+
 {{ $listNum }}. Forward local port to the application's pod:
   ```
   kubectl -n {{ .Release.Namespace }} wait --for=condition=available --timeout=60s deploy/{{ include "cryostat.fullname" . }}

--- a/charts/cryostat/templates/NOTES.txt
+++ b/charts/cryostat/templates/NOTES.txt
@@ -60,6 +60,6 @@
 {{- else if contains "LoadBalancer" .Values.core.service.type }}
   echo http://$SERVICE_IP:{{ .Values.core.service.httpPort }}
 {{- else if contains "ClusterIP" .Values.core.service.type }}
-  http://localhost:8080
+  echo http://localhost:8080
 {{- end }}
   ```

--- a/charts/cryostat/templates/NOTES.txt
+++ b/charts/cryostat/templates/NOTES.txt
@@ -1,8 +1,8 @@
 {{- $envVars := list }}
-{{- $portForwards := list }}
+{{- $portForwards := false }}
 {{- $listNum := 1 }}
 {{- if not .Values.core.ingress.enabled }}
-{{ $listNum }}. Tell Cryostat how to serve external traffic:
+{{ $listNum }}. Configure the application to serve external traffic:
 {{- $listNum = add1 $listNum }}
   ```
 {{- if .Values.core.route.enabled }}
@@ -11,6 +11,10 @@
 {{- else if .Values.core.ingress.enabled }}
 {{- /* Do nothing */}}
   No actions required with this configuration.
+{{- else if contains "ClusterIP" .Values.core.service.type }}
+  {{- /* Do nothing */}}
+  No actions required with this configuration.
+{{- $portForwards = true }}
 {{- else if contains "NodePort" .Values.core.service.type }}
   export NODE_IP=$(kubectl get nodes -n {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   export NODE_PORT=$(kubectl get -n {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cryostat.fullname" . }})
@@ -20,10 +24,6 @@
            You can watch the status by running 'kubectl get -n {{ .Release.Namespace }} -w svc/{{ include "cryostat.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc -n {{ .Release.Namespace }} {{ include "cryostat.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
 {{- $envVars = list "QUARKUS_HTTP_HOST=$SERVICE_IP" }}
-{{- else if contains "ClusterIP" .Values.core.service.type }}
-  export POD_NAME=$(kubectl get pods -n {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cryostat.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"  --sort-by=.metadata.creationTimestamp -o jsonpath="{.items[-1:].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod -n {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-{{- $portForwards = prepend $portForwards "8080:$CONTAINER_PORT" }}
 {{- end }}
 
 {{- if not (empty $envVars) }}
@@ -32,18 +32,19 @@
   ```
 {{- end }}
 
-{{- if not (empty $portForwards) }}
-
-{{ $listNum }}. Forward local ports to the application's pod:
+{{- if $portForwards }}
+{{ $listNum }}. Forward local port to the application's pod:
   ```
-  export POD_NAME=$(kubectl get pods -n {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cryostat.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"  --sort-by=.metadata.creationTimestamp -o jsonpath="{.items[-1:].metadata.name}")
   kubectl -n {{ .Release.Namespace }} wait --for=condition=available --timeout=60s deploy/{{ include "cryostat.fullname" . }}
-  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME {{ join " " $portForwards }}
+
+  export POD_NAME=$(kubectl get pods -n {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "cryostat.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" --sort-by=.metadata.creationTimestamp -o jsonpath="{.items[-1:].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod -n {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME "8080:$CONTAINER_PORT"
   ```
   {{- $listNum = add1 $listNum }}
 {{- end }}
 
-{{ $listNum }}. {{ "Visit the " }}{{ .Chart.Name | camelcase }}{{ " application at: " }}
+{{ $listNum }}. Visit the application at:
   ```
 {{- if .Values.core.route.enabled }}
   echo {{ ternary "https" "http" .Values.core.route.tls.enabled }}://$(oc get route -n {{ .Release.Namespace }} {{ include "cryostat.fullname" . }} -o jsonpath="{.status.ingress[0].host}")

--- a/charts/cryostat/tests/notes_test.yaml
+++ b/charts/cryostat/tests/notes_test.yaml
@@ -128,5 +128,5 @@ tests:
           
             3. Visit the application at:
               ```
-              http://localhost:8080
+              echo http://localhost:8080
               ```

--- a/charts/cryostat/tests/notes_test.yaml
+++ b/charts/cryostat/tests/notes_test.yaml
@@ -28,7 +28,7 @@ tests:
               https://example.com/
               ```
 
-  - it: should render notes for enabled route without TLS
+  - it: should render correct notes for enabled route without TLS
     set:
       core.route.enabled: true
       core.route.tls.enabled: false
@@ -46,7 +46,7 @@ tests:
               echo http://$(oc get route -n NAMESPACE RELEASE-NAME-cryostat -o jsonpath="{.status.ingress[0].host}")
               ```
 
-  - it: should render notes for enabled route with TLS
+  - it: should render correct notes for enabled route with TLS
     set:
       core.route.enabled: true
       core.route.tls.enabled: true
@@ -64,7 +64,7 @@ tests:
               echo https://$(oc get route -n NAMESPACE RELEASE-NAME-cryostat -o jsonpath="{.status.ingress[0].host}")
               ```
   
-  - it: should render notes for NodePort service without ingress or route
+  - it: should render correct notes for NodePort service without ingress or route
     set:
       core.service.type: "NodePort"
       core.ingress.enabled: false
@@ -85,7 +85,7 @@ tests:
               echo http://$NODE_IP:$NODE_PORT
               ```
 
-  - it: should render notes for LoadBalancer service without ingress or route
+  - it: should render correct notes for LoadBalancer service without ingress or route
     set:
       core.service.type: "LoadBalancer"
       core.ingress.enabled: false
@@ -105,4 +105,28 @@ tests:
             2. Visit the application at:
               ```
               echo http://$SERVICE_IP:8181
+              ```
+
+  - it: should render correct notes for ClusterIP service without ingress or route
+    asserts:
+      - equalRaw:
+          value: |
+
+            1. Configure the application to serve external traffic:
+              ```
+              No actions required with this configuration.
+              ```
+
+            2. Forward local port to the application's pod:
+              ```
+              kubectl -n NAMESPACE wait --for=condition=available --timeout=60s deploy/RELEASE-NAME-cryostat
+          
+              export POD_NAME=$(kubectl get pods -n NAMESPACE -l "app.kubernetes.io/name=cryostat,app.kubernetes.io/instance=RELEASE-NAME" --sort-by=.metadata.creationTimestamp -o jsonpath="{.items[-1:].metadata.name}")
+              export CONTAINER_PORT=$(kubectl get pod -n NAMESPACE $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+              kubectl -n NAMESPACE port-forward $POD_NAME "8080:$CONTAINER_PORT"
+              ```
+          
+            3. Visit the application at:
+              ```
+              http://localhost:8080
               ```

--- a/charts/cryostat/tests/notes_test.yaml
+++ b/charts/cryostat/tests/notes_test.yaml
@@ -120,12 +120,12 @@ tests:
             2. Forward local port to the application's pod:
               ```
               kubectl -n NAMESPACE wait --for=condition=available --timeout=60s deploy/RELEASE-NAME-cryostat
-          
+
               export POD_NAME=$(kubectl get pods -n NAMESPACE -l "app.kubernetes.io/name=cryostat,app.kubernetes.io/instance=RELEASE-NAME" --sort-by=.metadata.creationTimestamp -o jsonpath="{.items[-1:].metadata.name}")
               export CONTAINER_PORT=$(kubectl get pod -n NAMESPACE $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
               kubectl -n NAMESPACE port-forward $POD_NAME "8080:$CONTAINER_PORT"
               ```
-          
+
             3. Visit the application at:
               ```
               echo http://localhost:8080

--- a/charts/cryostat/tests/notes_test.yaml
+++ b/charts/cryostat/tests/notes_test.yaml
@@ -25,7 +25,7 @@ tests:
 
             1. Visit the application at:
               ```
-              https://example.com/
+              echo https://example.com/
               ```
 
   - it: should render correct notes for enabled route without TLS

--- a/charts/cryostat/tests/notes_test.yaml
+++ b/charts/cryostat/tests/notes_test.yaml
@@ -23,7 +23,7 @@ tests:
           value: |
 
 
-            1. Visit the Cryostat application at:
+            1. Visit the application at:
               ```
               https://example.com/
               ```
@@ -36,12 +36,12 @@ tests:
       - equalRaw:
           value: |
 
-            1. Tell Cryostat how to serve external traffic:
+            1. Configure the application to serve external traffic:
               ```
               No actions required with this configuration.
               ```
 
-            2. Visit the Cryostat application at:
+            2. Visit the application at:
               ```
               echo http://$(oc get route -n NAMESPACE RELEASE-NAME-cryostat -o jsonpath="{.status.ingress[0].host}")
               ```
@@ -54,12 +54,12 @@ tests:
       - equalRaw:
           value: |
 
-            1. Tell Cryostat how to serve external traffic:
+            1. Configure the application to serve external traffic:
               ```
               No actions required with this configuration.
               ```
 
-            2. Visit the Cryostat application at:
+            2. Visit the application at:
               ```
               echo https://$(oc get route -n NAMESPACE RELEASE-NAME-cryostat -o jsonpath="{.status.ingress[0].host}")
               ```
@@ -73,14 +73,14 @@ tests:
       - equalRaw:
           value: |
 
-            1. Tell Cryostat how to serve external traffic:
+            1. Configure the application to serve external traffic:
               ```
               export NODE_IP=$(kubectl get nodes -n NAMESPACE -o jsonpath="{.items[0].status.addresses[0].address}")
               export NODE_PORT=$(kubectl get -n NAMESPACE -o jsonpath="{.spec.ports[0].nodePort}" services RELEASE-NAME-cryostat)
               kubectl -n NAMESPACE set env deploy --containers=cryostat RELEASE-NAME-cryostat QUARKUS_HTTP_HOST=$NODE_IP
               ```
 
-            2. Visit the Cryostat application at:
+            2. Visit the application at:
               ```
               echo http://$NODE_IP:$NODE_PORT
               ```
@@ -94,7 +94,7 @@ tests:
       - equalRaw:
           value: |
 
-            1. Tell Cryostat how to serve external traffic:
+            1. Configure the application to serve external traffic:
               ```
                  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
                        You can watch the status by running 'kubectl get -n NAMESPACE -w svc/RELEASE-NAME-cryostat'
@@ -102,7 +102,7 @@ tests:
               kubectl -n NAMESPACE set env deploy --containers=cryostat RELEASE-NAME-cryostat QUARKUS_HTTP_HOST=$SERVICE_IP
               ```
 
-            2. Visit the Cryostat application at:
+            2. Visit the application at:
               ```
               echo http://$SERVICE_IP:8181
               ```

--- a/charts/cryostat/tests/notes_test.yaml
+++ b/charts/cryostat/tests/notes_test.yaml
@@ -25,7 +25,7 @@ tests:
 
             1. Visit the application at:
               ```
-              echo https://example.com/
+              https://example.com/
               ```
 
   - it: should render correct notes for enabled route without TLS
@@ -63,7 +63,7 @@ tests:
               ```
               echo https://$(oc get route -n NAMESPACE RELEASE-NAME-cryostat -o jsonpath="{.status.ingress[0].host}")
               ```
-  
+
   - it: should render correct notes for NodePort service without ingress or route
     set:
       core.service.type: "NodePort"
@@ -128,5 +128,5 @@ tests:
 
             3. Visit the application at:
               ```
-              echo http://localhost:8080
+              http://localhost:8080
               ```


### PR DESCRIPTION
Related to #177, #160 

## Descriptions

- Simplify post-install steps for ClusterIP service case.
- Use generic word `application` to refer to Cryostat in release notes. I suppose installing Cryostat chart already means installing Cryostat (See https://github.com/cryostatio/cryostat-helm/pull/177#issuecomment-2234258284)

## Motivations

When installing the chart without further customizations, the user just needs to port-forward the local port to the application pod. Previously, there were some extra steps that only defined some environment variables (i.e. not actually configuring cryostat).

## How to test

```
helm install cryostat-sample charts/cryostat
```

Expected notes:

````
NOTES:

1. Configure the application to serve external traffic:
  ```
  No actions required with this configuration.
  ```

2. Forward local port to the application's pod:
  ```
  kubectl -n default wait --for=condition=available --timeout=60s deploy/cryostat-sample

  export POD_NAME=$(kubectl get pods -n default -l "app.kubernetes.io/name=cryostat,app.kubernetes.io/instance=cryostat-sample" --sort-by=.metadata.creationTimestamp -o jsonpath="{.items[-1:].metadata.name}")
  export CONTAINER_PORT=$(kubectl get pod -n default $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
  kubectl -n default port-forward $POD_NAME "8080:$CONTAINER_PORT"
  ```

3. Visit the application at:
  ```
  http://localhost:8080
  ```
````