### PR TITLE
fix(authproxy): cookie secret creation and reference using env valueFrom

### DIFF
--- a/charts/cryostat/templates/_helpers.tpl
+++ b/charts/cryostat/templates/_helpers.tpl
@@ -124,13 +124,12 @@ Generate or retrieve a default value for cookieSecret.
 {{/*
    Use the current secret. Do not regenerate.
 */}}
-{{- $secret.data.COOKIE_SECRET | b64dec | quote -}}
+{{- $secret.data.COOKIE_SECRET -}}
 {{- else -}}
 {{/*
     Generate a new secret.
 */}}
-{{- $newSecret := randAlphaNum 24 | b64enc -}}
-{{- $newSecret | quote -}}
+{{- (randAlphaNum 24) | b64enc | quote -}}
 {{- end }}
 {{- end }}
 

--- a/charts/cryostat/templates/_helpers.tpl
+++ b/charts/cryostat/templates/_helpers.tpl
@@ -116,6 +116,24 @@ Get or generate a default secret key for object storage.
 {{- end -}}
 
 {{/*
+Get or generate a default secret key for auth proxy cookies.
+*/}}
+{{- define "cryostat.cookieSecret" -}}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-cookie-secret" .Release.Name)) -}}
+{{- if $secret -}}
+{{/*
+   Use current secret. Do not regenerate.
+*/}}
+{{- $secret.data.COOKIE_SECRET -}}
+{{- else -}}
+{{/*
+    Generate new secret
+*/}}
+{{- (randAlphaNum 32) | b64enc | quote -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
     Get sanitized list or defaults (if not disabled) as comma-separated list.
 */}}
 {{- define "cryostat.commaSepList" -}}

--- a/charts/cryostat/templates/_helpers.tpl
+++ b/charts/cryostat/templates/_helpers.tpl
@@ -116,24 +116,6 @@ Get or generate a default secret key for object storage.
 {{- end -}}
 
 {{/*
-Generate or retrieve a default value for cookieSecret.
-*/}}
-{{- define "cryostat.cookieSecret" -}}
-{{- $secret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-cookie-secret" .Release.Name)) -}}
-{{- if $secret -}}
-{{/*
-   Use the current secret. Do not regenerate.
-*/}}
-{{- $secret.data.COOKIE_SECRET -}}
-{{- else -}}
-{{/*
-    Generate a new secret.
-*/}}
-{{- (randAlphaNum 24) | b64enc | quote -}}
-{{- end }}
-{{- end }}
-
-{{/*
     Get sanitized list or defaults (if not disabled) as comma-separated list.
 */}}
 {{- define "cryostat.commaSepList" -}}

--- a/charts/cryostat/templates/_oauth2Proxy.tpl
+++ b/charts/cryostat/templates/_oauth2Proxy.tpl
@@ -13,7 +13,11 @@ Create OAuth2 Proxy container. Configurations defined in alpha_config.yaml
     - name: OAUTH2_PROXY_REDIRECT_URL
       value: "http://localhost:4180/oauth2/callback"
     - name: OAUTH2_PROXY_COOKIE_SECRET
-      value: {{ include "cryostat.cookieSecret" . | b64dec | quote }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Release.Name }}-cookie-secret
+          key: COOKIE_SECRET
+          optional: false
     - name: OAUTH2_PROXY_EMAIL_DOMAINS
       value: "*"
     {{- if .Values.authentication.basicAuth.enabled }}

--- a/charts/cryostat/templates/_oauth2Proxy.tpl
+++ b/charts/cryostat/templates/_oauth2Proxy.tpl
@@ -13,7 +13,7 @@ Create OAuth2 Proxy container. Configurations defined in alpha_config.yaml
     - name: OAUTH2_PROXY_REDIRECT_URL
       value: "http://localhost:4180/oauth2/callback"
     - name: OAUTH2_PROXY_COOKIE_SECRET
-      value: {{ include "cryostat.cookieSecret" . }}
+      value: {{ include "cryostat.cookieSecret" . | b64dec | quote }}
     - name: OAUTH2_PROXY_EMAIL_DOMAINS
       value: "*"
     {{- if .Values.authentication.basicAuth.enabled }}

--- a/charts/cryostat/templates/_openshiftOauthProxy.tpl
+++ b/charts/cryostat/templates/_openshiftOauthProxy.tpl
@@ -14,7 +14,7 @@ Create OpenShift OAuth Proxy container.
     - --upstream=http://localhost:8181/
     - --upstream=http://localhost:3000/grafana/
     - --upstream=http://localhost:8333/storage/
-    - --cookie-secret={{ include "cryostat.cookieSecret" . }}
+    - --cookie-secret={{ include "cryostat.cookieSecret" . | b64dec | quote }}
     - --openshift-service-account={{ include "cryostat.serviceAccountName" . }}
     - --proxy-websockets=true
     - --http-address=0.0.0.0:4180

--- a/charts/cryostat/templates/_openshiftOauthProxy.tpl
+++ b/charts/cryostat/templates/_openshiftOauthProxy.tpl
@@ -6,6 +6,13 @@ Create OpenShift OAuth Proxy container.
   securityContext:
     {{- toYaml .Values.openshiftOauthProxy.securityContext | nindent 4 }}
   image: "{{ .Values.openshiftOauthProxy.image.repository }}:{{ .Values.openshiftOauthProxy.image.tag }}"
+  env:
+    - name: COOKIE_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Release.Name }}-cookie-secret
+          key: COOKIE_SECRET
+          optional: false
   args:
     - --skip-provider-button={{ not .Values.authentication.basicAuth.enabled }}
     - --pass-access-token=false
@@ -14,7 +21,7 @@ Create OpenShift OAuth Proxy container.
     - --upstream=http://localhost:8181/
     - --upstream=http://localhost:3000/grafana/
     - --upstream=http://localhost:8333/storage/
-    - --cookie-secret={{ include "cryostat.cookieSecret" . | b64dec | quote }}
+    - --cookie-secret="$(COOKIE_SECRET)"
     - --openshift-service-account={{ include "cryostat.serviceAccountName" . }}
     - --proxy-websockets=true
     - --http-address=0.0.0.0:4180

--- a/charts/cryostat/templates/cookie_secret.yaml
+++ b/charts/cryostat/templates/cookie_secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-cookie-secret
+type: Opaque
+data:
+  COOKIE_SECRET: {{ include "cryostat.cookieSecret" . }}

--- a/charts/cryostat/templates/cookie_secret.yaml
+++ b/charts/cryostat/templates/cookie_secret.yaml
@@ -1,7 +1,13 @@
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-cookie-secret" .Release.Name)) -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-cookie-secret
 type: Opaque
+{{ if $secret -}}
+data:
+  COOKIE_SECRET: {{ $secret.data.COOKIE_SECRET }}
+{{ else -}}
 stringData:
   COOKIE_SECRET: {{ randAlphaNum 32 }}
+{{ end }}

--- a/charts/cryostat/templates/cookie_secret.yaml
+++ b/charts/cryostat/templates/cookie_secret.yaml
@@ -3,5 +3,5 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-cookie-secret
 type: Opaque
-data:
-  COOKIE_SECRET: {{ include "cryostat.cookieSecret" . }}
+stringData:
+  COOKIE_SECRET: {{ randAlphaNum 32 }}

--- a/charts/cryostat/templates/cookie_secret.yaml
+++ b/charts/cryostat/templates/cookie_secret.yaml
@@ -1,13 +1,7 @@
-{{- $secret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-cookie-secret" .Release.Name)) -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-cookie-secret
 type: Opaque
-{{ if $secret -}}
 data:
-  COOKIE_SECRET: {{ $secret.data.COOKIE_SECRET }}
-{{ else -}}
-stringData:
-  COOKIE_SECRET: {{ randAlphaNum 32 }}
-{{ end }}
+  COOKIE_SECRET: {{ include "cryostat.cookieSecret" . }}

--- a/charts/cryostat/tests/cookie_secret_test.yaml
+++ b/charts/cryostat/tests/cookie_secret_test.yaml
@@ -1,0 +1,20 @@
+suite: test cookie_secret.yaml
+templates:
+  - cookie_secret.yaml
+
+tests:
+  - it: should create a Cookie Secret with correct settings
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-cookie-secret
+      - equal:
+          path: type
+          value: Opaque
+      - exists:
+          path: data.COOKIE_SECRET

--- a/charts/cryostat/tests/cookie_secret_test.yaml
+++ b/charts/cryostat/tests/cookie_secret_test.yaml
@@ -17,4 +17,4 @@ tests:
           path: type
           value: Opaque
       - exists:
-          path: stringData.COOKIE_SECRET
+          path: data.COOKIE_SECRET

--- a/charts/cryostat/tests/cookie_secret_test.yaml
+++ b/charts/cryostat/tests/cookie_secret_test.yaml
@@ -17,4 +17,4 @@ tests:
           path: type
           value: Opaque
       - exists:
-          path: data.COOKIE_SECRET
+          path: stringData.COOKIE_SECRET


### PR DESCRIPTION
## Description

### Fix

- Added relevant cookie secret.
- Added test for cookie secret.

## Motivations 
There was no cookie secret to be looked up in subsequent helm upgrade.