### PR TITLE
fix(configmaps): skip creating configmap for Alpha Configurations when used with OCP Proxy

### DIFF
--- a/charts/cryostat/templates/alpha_config.yaml
+++ b/charts/cryostat/templates/alpha_config.yaml
@@ -1,7 +1,13 @@
+{{/*
+   Alpha Configuration is not used with OpenShift OAuth Proxy
+*/}}
+{{- if not (.Values.authentication.openshift).enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-alpha-config
+  labels:
+    {{- include "cryostat.labels" . | nindent 4 }}
 data:
   alpha_config.yaml: |-
     server:
@@ -15,15 +21,10 @@ data:
         - id: grafana
           path: /grafana/
           uri: http://localhost:3000
-        - id: storage
-          path: ^/storage/(.*)$
-          rewriteTarget: /$1
-          uri: http://localhost:8333
-          passHostHeader: false
-          proxyWebSockets: false
     providers:
       - id: dummy
         name: Unused - Sign In Below
         clientId: CLIENT_ID
         clientSecret: CLIENT_SECRET
         provider: google
+{{- end }}

--- a/charts/cryostat/templates/alpha_config.yaml
+++ b/charts/cryostat/templates/alpha_config.yaml
@@ -21,6 +21,12 @@ data:
         - id: grafana
           path: /grafana/
           uri: http://localhost:3000
+        - id: storage
+          path: ^/storage/(.*)$
+          rewriteTarget: /$1
+          uri: http://localhost:8333
+          passHostHeader: false
+          proxyWebSockets: false
     providers:
       - id: dummy
         name: Unused - Sign In Below

--- a/charts/cryostat/templates/deployment.yaml
+++ b/charts/cryostat/templates/deployment.yaml
@@ -265,9 +265,11 @@ spec:
       - name: {{ .Chart.Name }}
         emptyDir: {}
       {{- end }}
+      {{- if not (.Values.authentication.openshift).enabled }}
       - name: alpha-config
         configMap:
           name: {{ .Release.Name }}-alpha-config
+      {{- end }}
       {{- if .Values.authentication.basicAuth.enabled }}
       - name: {{ .Release.Name }}-htpasswd
         secret:

--- a/charts/cryostat/tests/alpha_config_test.yaml
+++ b/charts/cryostat/tests/alpha_config_test.yaml
@@ -3,14 +3,11 @@ templates:
   - templates/alpha_config.yaml
 
 tests:
-  - it: should contain server configuration in alpha_config.yaml
+  - it: should create configmap with correct alpha configurations
     asserts:
       - matchRegex:
           path: data['alpha_config.yaml']
           pattern: "server:\\s*BindAddress: http://0.0.0.0:4180"
-
-  - it: should contain upstream configurations in alpha_config.yaml
-    asserts:
       - matchRegex:
           path: data['alpha_config.yaml']
           pattern: "upstreamConfig:\\s*proxyRawPath: true\\s*upstreams:\\s*- id: cryostat\\s*path: /\\s*uri: http://localhost:8181"
@@ -19,10 +16,13 @@ tests:
           pattern: "- id: grafana\\s*path: /grafana/\\s*uri: http://localhost:3000"
       - matchRegex:
           path: data['alpha_config.yaml']
-          pattern: "- id: storage\\s*path: \\^/storage/\\(\\.\\*\\)\\$\\s*rewriteTarget: /\\$1\\s*uri: http://localhost:8333\\s*passHostHeader: false\\s*proxyWebSockets: false"
-
-  - it: should contain provider configuration in alpha_config.yaml
-    asserts:
-      - matchRegex:
-          path: data['alpha_config.yaml']
           pattern: "providers:\\s*- id: dummy\\s*name: Unused - Sign In Below\\s*clientId: CLIENT_ID\\s*clientSecret: CLIENT_SECRET\\s*provider: google"
+
+  - it: should not create alpha_config when openshift authentication is enabled
+    set:
+      authentication:
+        openshift:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/cryostat/tests/alpha_config_test.yaml
+++ b/charts/cryostat/tests/alpha_config_test.yaml
@@ -16,6 +16,9 @@ tests:
           pattern: "- id: grafana\\s*path: /grafana/\\s*uri: http://localhost:3000"
       - matchRegex:
           path: data['alpha_config.yaml']
+          pattern: "- id: storage\\s*path: \\^/storage/\\(\\.\\*\\)\\$\\s*rewriteTarget: /\\$1\\s*uri: http://localhost:8333\\s*passHostHeader: false\\s*proxyWebSockets: false"
+      - matchRegex:
+          path: data['alpha_config.yaml']
           pattern: "providers:\\s*- id: dummy\\s*name: Unused - Sign In Below\\s*clientId: CLIENT_ID\\s*clientSecret: CLIENT_SECRET\\s*provider: google"
 
   - it: should not create alpha_config when openshift authentication is enabled


### PR DESCRIPTION
## What's changed

- Added a condition to only create `alpha-config` ConfigMap when openshift authentication is not enabled (i.e. with OAuth2-Proxy).
- Added common labels to the generated ConfigMap. Just good practice for easy querying :D

## Motivations

I think it's a good to determine and create only necessary resources. This would be helpful in case the namespace has resource quota.

Related to #127 