### PR TITLE
feat(template): add major version suffix to deployment names

### DIFF
--- a/charts/cryostat/templates/_helpers.tpl
+++ b/charts/cryostat/templates/_helpers.tpl
@@ -145,3 +145,11 @@ Get or generate a default secret key for auth proxy cookies.
 {{- end -}}
 {{- join "," (default list $l | compact | uniq) | quote -}}
 {{- end -}}
+
+{{/*
+Get the name for managed deployments.
+*/}}
+{{- define "cryostat.deploymentName" -}}
+{{- $version := semver .Chart.AppVersion -}}
+{{- printf "%s-v%d" (include "cryostat.fullname" .) $version.Major -}}
+{{- end -}}

--- a/charts/cryostat/templates/cryostat_deployment.yaml
+++ b/charts/cryostat/templates/cryostat_deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cryostat.fullname" . }}
+  name: {{ include "cryostat.deploymentName" . }}
   labels:
     {{- include "cryostat.labels" . | nindent 4 }}
     app.kubernetes.io/component: cryostat

--- a/charts/cryostat/templates/db_deployment.yaml
+++ b/charts/cryostat/templates/db_deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cryostat.fullname" . }}-db
+  name: {{ include "cryostat.deploymentName" . }}-db
   labels:
     {{- include "cryostat.labels" . | nindent 4 }}
     app.kubernetes.io/component: db

--- a/charts/cryostat/templates/reports_deployment.yaml
+++ b/charts/cryostat/templates/reports_deployment.yaml
@@ -4,7 +4,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cryostat.fullname" . }}-reports
+  name: {{ include "cryostat.deploymentName" . }}-reports
   labels:
     {{- include "cryostat.labels" . | nindent 4 }}
     app.kubernetes.io/component: reports

--- a/charts/cryostat/templates/storage_deployment.yaml
+++ b/charts/cryostat/templates/storage_deployment.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "cryostat.fullname" . }}-storage
+  name: {{ include "cryostat.deploymentName" . }}-storage
   labels:
     {{- include "cryostat.labels" . | nindent 4 }}
     app.kubernetes.io/component: storage

--- a/charts/cryostat/tests/cryostat_deployment_test.yaml
+++ b/charts/cryostat/tests/cryostat_deployment_test.yaml
@@ -10,7 +10,7 @@ tests:
           value: Deployment
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-cryostat
+          value: RELEASE-NAME-cryostat-v4
       - equal:
           path: spec.replicas
           value: 1

--- a/charts/cryostat/tests/db_deployment_test.yaml
+++ b/charts/cryostat/tests/db_deployment_test.yaml
@@ -10,7 +10,7 @@ tests:
           value: Deployment
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-cryostat-db
+          value: RELEASE-NAME-cryostat-v4-db
       - equal:
           path: spec.replicas
           value: 1

--- a/charts/cryostat/tests/reports_deployment_test.yaml
+++ b/charts/cryostat/tests/reports_deployment_test.yaml
@@ -18,7 +18,7 @@ tests:
           value: Deployment
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-cryostat-reports
+          value: RELEASE-NAME-cryostat-v4-reports
       - equal:
           path: spec.replicas
           value: 2

--- a/charts/cryostat/tests/storage_deployment_test.yaml
+++ b/charts/cryostat/tests/storage_deployment_test.yaml
@@ -10,7 +10,7 @@ tests:
           value: Deployment
       - equal:
           path: metadata.name
-          value: RELEASE-NAME-cryostat-storage
+          value: RELEASE-NAME-cryostat-v4-storage
       - equal:
           path: spec.replicas
           value: 1


### PR DESCRIPTION
Related to #200 
Related to #192 

## Description of changes

Added a major version suffix to deployment such that breaking changes can recreate the deployment (i.e. selector changes)

## Notes

I stopped short of doing the same for other resources since they might introduce more breaking behaviors than intended. Also, resources such as secrets and configmaps can (i think) still be reused from 3.x version for seamless upgrades :D

The CI runs on this PR do not actually reflect these changes (i.e. no immutable fields are updated). We will need to manually run the steps below to check :D

## How to test

### Manual upgrade tests

```console
$ helm search repo cryostat
NAME               	CHART VERSION	APP VERSION	DESCRIPTION                                       
cryostatio/cryostat	1.0.1        	3.0.1      	Securely manage JFR recordings for your contain...

# Install 1.0.1 version
$ helm install cryostat-sample cryostatio/cryostat

# on this PR, upgrade 2.0.0-dev version
# This should now succeed without any errors
$ helm upgrade cryostat-sample charts/cryostat/

$ helm history cryostat-sample 
REVISION	UPDATED                 	STATUS    	CHART             	APP VERSION	DESCRIPTION     
1       	Tue Sep 24 13:37:42 2024	superseded	cryostat-1.0.1    	3.0.1      	Install complete
2       	Tue Sep 24 13:38:22 2024	deployed  	cryostat-2.0.0-dev	4.0.0-dev  	Upgrade complete
```

### With chart-testing

```console
# This will install/upgrade and run helm tests
bash ct.bash --upgrade
```