### PR TITLE
fix(serviceaccount): non-Cryostat Pods run as default serviceaccount

### DIFF
--- a/charts/cryostat/templates/db_deployment.yaml
+++ b/charts/cryostat/templates/db_deployment.yaml
@@ -29,7 +29,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "cryostat.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/cryostat/templates/reports_deployment.yaml
+++ b/charts/cryostat/templates/reports_deployment.yaml
@@ -30,7 +30,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "cryostat.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/cryostat/templates/storage_deployment.yaml
+++ b/charts/cryostat/templates/storage_deployment.yaml
@@ -29,7 +29,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "cryostat.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/cryostat/tests/cryostat_service_test.yaml
+++ b/charts/cryostat/tests/cryostat_service_test.yaml
@@ -190,6 +190,6 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: cryostat
             app.kubernetes.io/part-of: cryostat
-            app.kubernetes.io/version: "4.0.0-dev"
+            app.kubernetes.io/version: "4.1.0-dev"
             helm.sh/chart: cryostat-2.0.0-dev
             app.kubernetes.io/component: cryostat

--- a/charts/cryostat/tests/cryostat_tls_secret_test.yaml
+++ b/charts/cryostat/tests/cryostat_tls_secret_test.yaml
@@ -32,7 +32,7 @@ tests:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: cryostat
             app.kubernetes.io/part-of: cryostat
-            app.kubernetes.io/version: 4.0.0-dev
+            app.kubernetes.io/version: 4.1.0-dev
             helm.sh/chart: cryostat-2.0.0-dev
 
   - it: should not create a TLS cert secret if oauth2Proxy.tls.selfSigned.enabled is not set

--- a/charts/cryostat/tests/db_deployment_test.yaml
+++ b/charts/cryostat/tests/db_deployment_test.yaml
@@ -31,9 +31,8 @@ tests:
             app.kubernetes.io/name: cryostat
             app.kubernetes.io/component: db
             app.kubernetes.io/part-of: cryostat
-      - equal:
+      - notExists:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-cryostat
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot
           value: true

--- a/charts/cryostat/tests/reports_deployment_test.yaml
+++ b/charts/cryostat/tests/reports_deployment_test.yaml
@@ -39,9 +39,8 @@ tests:
             app.kubernetes.io/name: cryostat
             app.kubernetes.io/part-of: cryostat
             app.kubernetes.io/component: reports
-      - equal:
+      - notExists:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-cryostat
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot
           value: true

--- a/charts/cryostat/tests/storage_deployment_test.yaml
+++ b/charts/cryostat/tests/storage_deployment_test.yaml
@@ -31,9 +31,8 @@ tests:
             app.kubernetes.io/name: cryostat
             app.kubernetes.io/component: storage
             app.kubernetes.io/part-of: cryostat
-      - equal:
+      - notExists:
           path: spec.template.spec.serviceAccountName
-          value: RELEASE-NAME-cryostat
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot
           value: true


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat-helm/issues/220

To test:
1. `helm install cryostat ./charts/cryostat`
2. Follow post-install port-forwarding steps
3. Deploy another sample application.
4. Open Cryostat Web UI and click around. Everything should work as normal. Sample application should be discovered.
