### PR TITLE
WIP EndpointSlices discovery

### DIFF
--- a/charts/cryostat/templates/cryostat_deployment.yaml
+++ b/charts/cryostat/templates/cryostat_deployment.yaml
@@ -127,6 +127,18 @@ spec:
             value: {{ include "cryostat.commaSepList" (list .portNumbers 9091 .builtInPortNumbersDisabled) }}
           {{- end }}
           {{- end }}
+          {{- if .Values.core.discovery.kubernetes2.enabled }}
+          - name: CRYOSTAT_DISCOVERY_KUBERNETES2_ENABLED
+            value: "true"
+          {{- with .Values.core.discovery.kubernetes }}
+          - name: CRYOSTAT_DISCOVERY_KUBERNETES_NAMESPACES
+            value: {{ include "cryostat.commaSepList" (list .namespaces $.Release.Namespace .installNamespaceDisabled) }}
+          - name: CRYOSTAT_DISCOVERY_KUBERNETES_PORT_NAMES
+            value: {{ include "cryostat.commaSepList" (list .portNames "jfr-jmx" .builtInPortNamesDisabled) }}
+          - name: CRYOSTAT_DISCOVERY_KUBERNETES_PORT_NUMBERS
+            value: {{ include "cryostat.commaSepList" (list .portNumbers 9091 .builtInPortNumbersDisabled) }}
+          {{- end }}
+          {{- end }}
           ports:
             - containerPort: 8181
               protocol: TCP

--- a/charts/cryostat/templates/role.yaml
+++ b/charts/cryostat/templates/role.yaml
@@ -19,6 +19,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - pods
@@ -50,7 +58,7 @@ rules:
 {{- end -}}
 {{- end -}}
 
-{{- if and .Values.rbac.create .Values.core.discovery.kubernetes.enabled -}}
+{{- if and .Values.rbac.create (or .Values.core.discovery.kubernetes.enabled .Values.core.discovery.kubernetes2.enabled) -}}
 {{- $watchNs := compact (default list .Values.core.discovery.kubernetes.namespaces) | uniq -}}
 {{- if and (not $watchNs) (not .Values.core.discovery.kubernetes.installNamespaceDisabled) -}}
 {{- $watchNs = list .Release.Namespace -}}

--- a/charts/cryostat/templates/rolebinding.yaml
+++ b/charts/cryostat/templates/rolebinding.yaml
@@ -20,7 +20,7 @@ subjects:
 {{- end -}}
 {{- end -}}
 
-{{- if and .Values.rbac.create .Values.core.discovery.kubernetes.enabled -}}
+{{- if and .Values.rbac.create (or .Values.core.discovery.kubernetes.enabled .Values.core.discovery.kubernetes2.enabled) -}}
 {{- $watchNs := compact (default list .Values.core.discovery.kubernetes.namespaces) | uniq -}}
 {{- if and (not $watchNs) (not .Values.core.discovery.kubernetes.installNamespaceDisabled) -}}
 {{- $watchNs = list .Release.Namespace -}}

--- a/charts/cryostat/values.yaml
+++ b/charts/cryostat/values.yaml
@@ -85,6 +85,9 @@ core:
       builtInPortNumbersDisabled: false
       ## @param core.discovery.kubernetes.portNumbers [array] List of port numbers that the Cryostat application should look for in order to consider a target as JMX connectable
       portNumbers: []
+    kubernetes2:
+      ## @param core.discovery.kubernetes2.enabled Enables Kubernetes API discovery mechanism
+      enabled: false
 
 ## @section Report Generator Deployment
 ## @extra reports Configuration for the Reports Generator deployment


### PR DESCRIPTION
Temporary PR to go along with https://github.com/cryostatio/cryostat/pull/740.

**THIS PR IS NOT MEANT TO BE MERGED**. This is only here for ease of deploying and testing the `EndpointSlices`-based discovery implementation. When that PR is ready on Cryostat itself, the old `Endpoints`-based discovery should be completely replaced as internal implementation details, reusing all the same config properties etc. The Helm chart should not actually need any updates to work with those internal changes.
