### PR TITLE
feat(reports): configure for reports presigned URL retrieval

### DIFF
--- a/charts/cryostat/templates/networkpolicy_ingress.yaml
+++ b/charts/cryostat/templates/networkpolicy_ingress.yaml
@@ -81,6 +81,13 @@ spec:
         namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      - podSelector:
+          matchLabels:
+            {{- include "cryostat.selectorLabels" $ | nindent 12 }}
+            app.kubernetes.io/component: reports
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: {{ .Release.Namespace }}
       ports:
         - protocol: TCP
           port: 8333

--- a/charts/cryostat/templates/reports_deployment.yaml
+++ b/charts/cryostat/templates/reports_deployment.yaml
@@ -47,6 +47,8 @@ spec:
             value: "{{ .Values.reports.service.httpPort }}"
           - name: QUARKUS_LOG_LEVEL
             value: {{ .Values.reports.debug.log.level }}
+          - name: CRYOSTAT_STORAGE_BASE_URI
+            value: http://{{ $fullName }}-storage:{{ .Values.storage.service.port }}
           {{- with (.Values.reports.config).extra.envVars }}
           {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/cryostat/tests/networkpolicy_ingress_test.yaml
+++ b/charts/cryostat/tests/networkpolicy_ingress_test.yaml
@@ -143,6 +143,15 @@ tests:
                     app.kubernetes.io/instance: RELEASE-NAME
                     app.kubernetes.io/name: cryostat
                     app.kubernetes.io/part-of: cryostat
+              - namespaceSelector:
+                  matchLabels:
+                    kubernetes.io/metadata.name: NAMESPACE
+                podSelector:
+                  matchLabels:
+                    app.kubernetes.io/component: reports
+                    app.kubernetes.io/instance: RELEASE-NAME
+                    app.kubernetes.io/name: cryostat
+                    app.kubernetes.io/part-of: cryostat
               ports:
                 - protocol: TCP
                   port: 8333


### PR DESCRIPTION
See also https://github.com/cryostatio/cryostat-operator/pull/1102
Related to https://github.com/cryostatio/cryostat/pull/856

To test:
1. deploy chart with `--set reports.replicas=1` (or more than 1) and `--set core.discovery.kubernetes.enabled=true --set core.discovery.kubernetes.namespaces='{apps1}'`
2. deploy sample application in `apps1`
3. open reports pod logs
4. open Cryostat UI, start a recording and request analysis of the sample application
5. verify that log messages appear in the reports pod indicating that it received the request for a presigned recording URL and processed it successfully
6. verify that the Cryostat UI updates with the analysis