### PR TITLE
fix(declarative): Fix declarative configuration mounting

### DIFF
--- a/charts/cryostat/templates/cryostat_deployment.yaml
+++ b/charts/cryostat/templates/cryostat_deployment.yaml
@@ -150,14 +150,14 @@ spec:
               mountPath: /opt/cryostat.d/templates.d/{{ . }}
               readOnly: true
           {{- end }}
-          {{- if .Values.core.config.rules.configMapNames}}
-            - name: declarative-rules
-              mountPath: /opt/cryostat.d/rules.d
+          {{- range  .Values.core.config.rules.configMapNames}}
+            - name: {{ . }}
+              mountPath: /opt/cryostat.d/rules.d/{{ . }}
               readOnly: true
           {{- end }}
-          {{- if .Values.core.config.probeTemplates.configMapNames}}
-            - name: declarative-probe-templates
-              mountPath: /opt/cryostat.d/probes.d
+          {{- range .Values.core.config.probeTemplates.configMapNames}}
+            - name: {{ . }}
+              mountPath: /opt/cryostat.d/probes.d/{{ . }}
               readOnly: true
           {{- end }}
           {{- range .Values.core.config.tlsTruststore.secretNames }}
@@ -165,9 +165,9 @@ spec:
               mountPath: /truststore/{{ . }}
               readOnly: true
           {{- end }}
-          {{- if .Values.core.config.credentials.secretNames }}
-            - name: declarative-credentials
-              mountPath: /opt/cryostat.d/credentials.d
+          {{- range .Values.core.config.credentials.secretNames }}
+            - name: {{ . }}
+              mountPath: /opt/cryostat.d/credentials.d/{{ . }}
               readOnly: true
           {{- end}}
         - name: {{ printf "%s-%s" .Chart.Name "grafana" }}
@@ -249,17 +249,6 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-oauth2proxy-tls
       {{- end }}
-      {{- if .Values.core.config.credentials.secretNames }}
-      - name: declarative-credentials
-        projected:
-          defaultMode: {{ .Values.core.config.declarative.fsMode }}
-          sources: 
-          {{- range .Values.core.config.credentials.secretNames }}
-            - secret:
-                secretName: {{ . }}
-                optional: false
-          {{- end }}
-      {{- end }}
       {{- range .Values.core.config.eventTemplates.configMapNames}}
       - name: {{ . }}
         configMap:
@@ -269,6 +258,12 @@ spec:
       - name: {{ . }}
         secret:
           secretName: {{ . }}
+      {{- end }}
+      {{- range .Values.core.config.credentials.secretNames }}
+      - name: {{ . }}
+        secret:
+          secretName: {{ . }}
+          optional: false
       {{- end }}
       {{- if .Values.core.config.probeTemplates.configMapNames}}
       - name: declarative-probe-templates

--- a/charts/cryostat/tests/cryostat_deployment_test.yaml
+++ b/charts/cryostat/tests/cryostat_deployment_test.yaml
@@ -745,8 +745,11 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name=='cryostat')].volumeMounts
           value:
-            - name: declarative-rules
-              mountPath: /opt/cryostat.d/rules.d
+            - name: a
+              mountPath: /opt/cryostat.d/rules.d/a
+              readOnly: true
+            - name: b
+              mountPath: /opt/cryostat.d/rules.d/b
               readOnly: true
       - equal:
           path: spec.template.spec.volumes
@@ -773,8 +776,11 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name=='cryostat')].volumeMounts
           value:
-            - name: declarative-rules
-              mountPath: /opt/cryostat.d/rules.d
+            - name: a
+              mountPath: /opt/cryostat.d/rules.d/a
+              readOnly: true
+            - name: b
+              mountPath: /opt/cryostat.d/rules.d/b
               readOnly: true
       - equal:
           path: spec.template.spec.volumes
@@ -800,8 +806,11 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name=='cryostat')].volumeMounts
           value:
-            - name: declarative-probe-templates
-              mountPath: /opt/cryostat.d/probes.d
+            - name: a
+              mountPath: /opt/cryostat.d/probes.d/a
+              readOnly: true
+            - name: b
+              mountPath: /opt/cryostat.d/probes.d/b
               readOnly: true
       - equal:
           path: spec.template.spec.volumes
@@ -828,8 +837,11 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name=='cryostat')].volumeMounts
           value: 
-            - name: declarative-probe-templates
-              mountPath: /opt/cryostat.d/probes.d
+            - name: a
+              mountPath: /opt/cryostat.d/probes.d/a
+              readOnly: true
+            - name: b
+              mountPath: /opt/cryostat.d/probes.d/b
               readOnly: true
       - equal:
           path: spec.template.spec.volumes
@@ -856,8 +868,11 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name=='cryostat')].volumeMounts
           value:
-            - name: declarative-credentials
-              mountPath: /opt/cryostat.d/credentials.d
+            - name: a
+              mountPath: /opt/cryostat.d/credentials.d/a
+              readOnly: true
+            - name: b
+              mountPath: /opt/cryostat.d/credentials.d/b
               readOnly: true
       - equal:
           path: spec.template.spec.volumes
@@ -865,13 +880,11 @@ tests:
             - name: alpha-config
               configMap:
                 name: RELEASE-NAME-alpha-config
-            - name: declarative-credentials
-              projected:
-                defaultMode: 0644
-                sources:
-                  - secret:
-                      secretName: a
-                      optional: false
-                  - secret:
-                      secretName: b
-                      optional: false  
+            - name: a
+              secret:
+                secretName: a
+                optional: false
+            - name: b
+              secret:
+                secretName: b
+                optional: false  


### PR DESCRIPTION
Fixes https://github.com/cryostatio/cryostat-helm/issues/244

To test:

- Start a cluster
- Intsall the helm chart
``` helm install --set core.image.repository=quay.io/jmatsuok/cryostat --set core.image.tag=4.1.0-snapshot --set core.route.enabled=true --set core.config.credentials.secretNames='{credential1}' cryostat ./charts/cryostat ```
- Check the cryostat deployment for the mounted secret
- Check the security view in cryostat to see that the secrets were found and imported