### PR TITLE
fix(cryostat): set QUARKUS_HTTP_HOST to 0.0.0.0

### DIFF
--- a/charts/cryostat/templates/cryostat_deployment.yaml
+++ b/charts/cryostat/templates/cryostat_deployment.yaml
@@ -48,7 +48,7 @@ spec:
           imagePullPolicy: {{ .Values.core.image.pullPolicy }}
           env:
           - name: QUARKUS_HTTP_HOST
-            value: localhost
+            value: 0.0.0.0
           - name: QUARKUS_LOG_LEVEL
             value: {{ .Values.core.debug.log.level }}
           - name: QUARKUS_HTTP_PORT

--- a/charts/cryostat/tests/cryostat_deployment_test.yaml
+++ b/charts/cryostat/tests/cryostat_deployment_test.yaml
@@ -69,7 +69,7 @@ tests:
           value: "INFO"
       - equal:
           path: spec.template.spec.containers[?(@.name=='cryostat')].env[?(@.name=='QUARKUS_HTTP_HOST')].value
-          value: "localhost"
+          value: "0.0.0.0"
       - equal:
           path: spec.template.spec.containers[?(@.name=='cryostat')].env[?(@.name=='QUARKUS_HTTP_PROXY_PROXY_ADDRESS_FORWARDING')].value
           value: "true"


### PR DESCRIPTION
Fixes #255
See cryostatio/cryostat#952

There was previously `JAVA_OPTS_APPEND=-Dquarkus.http.host=0.0.0.0` in the Dockerfile, and I moved that out to a Dockerfile env var `QUARKUS_HTTP_HOST=0.0.0.0` This should be equivalent, but they have [different precedence](https://quarkus.io/guides/config-reference#configuration-sources), and system properties take precedence over environment variables.
But, for whatever reason, the Operator and Helm Chart both define `QUARKUS_HTTP_HOST` on the Cryostat deployment as localhost. Because of the system property precedence this was basically just ignored previously, but now it is taking effect and overriding the environment variable set in the Dockerfile, and causing Cryostat to only bind on localhost - so the external probe from OpenShift fails.
